### PR TITLE
Postgres migrations, columns owner_id e public

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,11 +1,15 @@
 {
-  "type": "sqlite",
-  "database": "./src/database/database.sqlite",
-  "migrations": [
-    "./src/database/migrations/*.ts"
-  ],
+  "type": "postgres",
+  "host": "localhost",
+  "port": 5432,
+  "username": "postgres",
+  "password": "docker",
+  "database": "postgres",
   "entities": [
     "./src/models/*.ts"
+  ],
+  "migrations": [
+    "./src/database/migrations/*.ts"
   ],
   "cli": {
     "migrationsDir": "./src/database/migrations"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "discord.js": "^12.5.3",
     "dotenv": "^8.2.0",
     "ffmpeg-static": "^4.3.0",
+    "pg": "^8.6.0",
     "reflect-metadata": "^0.1.13",
     "sqlite": "^4.0.21",
     "sqlite3": "^5.0.2",

--- a/src/database/migrations/1620171366267-CreateSongs.ts
+++ b/src/database/migrations/1620171366267-CreateSongs.ts
@@ -1,4 +1,4 @@
-import {MigrationInterface, QueryRunner, Table} from "typeorm";
+import {MigrationInterface, QueryRunner, Table, TableForeignKey} from "typeorm";
 
 export class CreateSongs1620171366267 implements MigrationInterface {
 
@@ -8,14 +8,14 @@ export class CreateSongs1620171366267 implements MigrationInterface {
       columns: [
         {
           name: 'id',
-          type: 'integer',
+          type: 'int',
           isPrimary: true,
           isGenerated: true,
           generationStrategy: 'increment',
         },
         {
           name: 'playlist_id',
-          type: 'varchar',
+          type: 'integer',
         },
         {
           name: 'video_id',
@@ -30,18 +30,21 @@ export class CreateSongs1620171366267 implements MigrationInterface {
           type: 'varchar',
         }
       ],
-      foreignKeys: [
-        {
-          columnNames: [ 'playlist_id' ],
-          referencedColumnNames: [ 'id' ],
-          referencedTableName: 'playlist',
-          onDelete: 'CASCADE',
-        }
-      ]
+    }));
+
+    await queryRunner.createForeignKey('songs', new TableForeignKey({
+      name: 'PlaylistIdentification',
+      columnNames: ['playlist_id'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'playlist',
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
     }));
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('songs', 'PlaylistIdentification');
+
     await queryRunner.dropTable('songs');
   }
 

--- a/src/database/migrations/1620674868308-OwnerId.ts
+++ b/src/database/migrations/1620674868308-OwnerId.ts
@@ -1,0 +1,25 @@
+import {MigrationInterface, QueryRunner, TableColumn} from "typeorm";
+
+export class OwnerId1620674868308 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('playlist', new TableColumn({
+      name: 'owner_id',
+      type: 'uuid',
+      isNullable: true,
+    }),
+    );
+
+    await queryRunner.addColumn('playlist', new TableColumn({
+      name: 'public',
+      type: 'boolean',
+    }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('playlist', 'owner_id');
+    await queryRunner.dropColumn('playlist', 'public');
+  }
+
+}

--- a/src/models/Playlist.ts
+++ b/src/models/Playlist.ts
@@ -9,6 +9,12 @@ export class Playlist {
   name: string;
 
   @Column()
+  owner_id: string;
+
+  @Column()
+  public: boolean;
+
+  @Column()
   guild_id: string;
 
   constructor(props: Playlist) {


### PR DESCRIPTION
Adicionar migrations para mudar do banco de dados sqlite para o postgres. e adicionar as colunas owner_id e public na tabela playlist.