### PR TITLE
Adicionando configurações de produção

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn.lock
 # database
 src/database/database.sqlite
 
+# production
+dist/
+
 # environments variables
 .env
 .evn.local

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "outDir": "./dist",                             /* Redirect output structure to the directory. */
+    "rootDir": "./src",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */


### PR DESCRIPTION
## O que foi feito
Adicionando a pasta de produção,`dist` ao `.gitignore`, e adicionando pastas de desenvolvimento e produção ao `tsconfig.json`.


**tsconfig.json**
```json
"outDir": "dist",
"rootDir": "src"
```

**.gitignore**
```.gitignore
# production
dist/
```

## Motivo
Separar ambiente de desenvolvimento e produção, e adicionar `dist/` no `.gitignore` para não ficar sendo monitorado pelo **Git**, o que trás um maior facilidade de atualizar o ambiente de produção, evitando conflitos, na hora de atualizar o projeto e fazer build no ambiente de produção.